### PR TITLE
chore(readme): add wip note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Resolve a promise synchronously.
 
+*Note: this package is a work in progress. First release coming soon.*
+
+<!--
 [![NPM Badge](https://nodei.co/npm/p-sync.png)](https://npmjs.com/package/p-sync)
 
 ## Install
@@ -9,6 +12,7 @@ Resolve a promise synchronously.
 ```sh
 npm install p-sync
 ```
+-->
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Resolve a promise synchronously.
 
-*Note: this package is a work in progress. First release coming soon.*
+*Note: This package is yet to be released since `p-sync` has been "taken" by `psync` so I'm currently querying support.*
 
 <!--
 [![NPM Badge](https://nodei.co/npm/p-sync.png)](https://npmjs.com/package/p-sync)


### PR DESCRIPTION
I was happy to see this module and immediately ran `npm i p-sync` but it's not out yet.

By the way you should take it quickly... Release a 0.1.0 version or something just to guarantee the ownership of this name.

-----
[View rendered README.md](https://github.com/papb/p-sync/blob/patch-1/README.md)